### PR TITLE
fix: set Access-Control-Allow-Credentials to true in headers

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -45,7 +45,7 @@ const secrets = functions.config().doppler || {};
  * }
  */
 export const getUserByUid = functions.https.onRequest((req, res) => {
-  return cors({origin: true})(req, res, async () => {
+  return cors({origin: true, credentials: true})(req, res, async () => {
     try {
       if (secrets.ENV !== "dev" && await checkNameRateLimit(req.ip || "")) {
         throw new HexlinkError(429, "Too many requests");
@@ -95,7 +95,7 @@ export const getUserByUid = functions.https.onRequest((req, res) => {
  */
 export const registerUserWithPasskey =
   functions.https.onRequest((req, res) => {
-    return cors({origin: true})(req, res, async () => {
+    return cors({origin: true, credentials: true})(req, res, async () => {
       try {
         if (secrets.ENV !== "dev" && await registerRateLimit(req.ip || "")) {
           throw new HexlinkError(429, "Too many requests");
@@ -158,7 +158,7 @@ export const registerUserWithPasskey =
  */
 export const getPasskeyChallenge =
   functions.https.onRequest((req, res) => {
-    cors({origin: true})(req, res, async () => {
+    cors({origin: true, credentials: true})(req, res, async () => {
       try {
         if (secrets.ENV !== "dev" && await getChallengeRateLimit(req.ip || "")) {
           throw new HexlinkError(429, "Too many requests");
@@ -199,7 +199,7 @@ export const getPasskeyChallenge =
  */
 export const loginWithPasskey =
   functions.https.onRequest((req, res) => {
-    cors({origin: true})(req, res, async () => {
+    cors({origin: true, credentials: true})(req, res, async () => {
       try {
         const user = await getUser(req.body.address);
         if (user == null) {
@@ -259,7 +259,7 @@ export const loginWithPasskey =
  */
 export const getDataEncryptionKey =
   functions.https.onRequest((req, res) => {
-    cors({origin: true})(req, res, async () => {
+    cors({origin: true, credentials: true})(req, res, async () => {
       try {
         const firebaseIdToken = extractFirebaseIdToken(req);
         const decoded = await admin.auth().verifyIdToken(firebaseIdToken);


### PR DESCRIPTION
Got this error when calling backend: 
Access to XMLHttpRequest at 'http://127.0.0.1:5001/openid3-bbd1b/us-central1/getUserByUid' from origin 'http://localhost:3000' has been blocked by CORS policy: Response to preflight request doesn't pass access control check: The value of the 'Access-Control-Allow-Credentials' header in the response is '' which must be 'true' when the request's credentials mode is 'include'. The credentials mode of requests initiated by the XMLHttpRequest is controlled by the withCredentials attribute.

As stated here, we need to specify the credential variable in header to true to set the Access-Control-Allow-Credentials to true, reference: https://www.npmjs.com/package/cors#simple-usage-enable-all-cors-requests